### PR TITLE
fix: USB OTG FS PHY reset for reliable re-enumeration after st-flash

### DIFF
--- a/crates/microfips-core/Cargo.toml
+++ b/crates/microfips-core/Cargo.toml
@@ -13,7 +13,7 @@ sha2 = { version = "0.10", default-features = false, features = ["oid"] }
 k256 = { version = "0.13", default-features = false, features = ["arithmetic", "ecdsa", "ecdh"] }
 chacha20poly1305 = { version = "0.10", default-features = false }
 hkdf = { version = "0.12", default-features = false }
-hmac = { version = "0.12", default-features = false }
+hmac = { version = "0.13", default-features = false }
 hex = { version = "0.4", optional = true }
 log = { version = "0.4", optional = true }
 

--- a/crates/microfips-esp-transport/Cargo.toml
+++ b/crates/microfips-esp-transport/Cargo.toml
@@ -24,7 +24,7 @@ microfips-esp-common = { path = "../microfips-esp-common" }
 microfips-http-demo = { path = "../microfips-http-demo" }
 microfips-protocol = { path = "../microfips-protocol", features = ["log"] }
 microfips-service = { path = "../microfips-service" }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 esp-hal = { version = "1.0.0", features = ["unstable"] }
 embassy-time = "0.5.1"
 embassy-futures = "0.1.2"

--- a/crates/microfips-esp-transport/Cargo.toml
+++ b/crates/microfips-esp-transport/Cargo.toml
@@ -35,7 +35,7 @@ embedded-io-async = "0.7"
 heapless = "0.9"
 static_cell = "2"
 embassy-net = { version = "0.9.0", features = ["dhcpv4", "udp"], optional = true }
-esp-radio = { version = "0.17.0", default-features = false, features = ["ble", "wifi", "unstable"], optional = true }
+esp-radio = { version = "0.18.0", default-features = false, features = ["ble", "wifi", "unstable"], optional = true }
 trouble-host = { version = "0.6.0", features = ["default-packet-pool-mtu-255", "scan", "central"], optional = true }
 esp-alloc = { version = "0.9", optional = true }
 bt-hci = { version = "0.8", features = ["uuid"], optional = true }

--- a/crates/microfips-esp32/Cargo.toml
+++ b/crates/microfips-esp32/Cargo.toml
@@ -50,7 +50,7 @@ embassy-sync = "0.7.2"
 embedded-io-async = "0.7"
 heapless = "0.9"
 static_cell = "2"
-esp-radio = { version = "0.17.0", default-features = false, features = ["esp32", "ble", "wifi", "unstable"], optional = true }
+esp-radio = { version = "0.18.0", default-features = false, features = ["esp32", "ble", "wifi", "unstable"], optional = true }
 trouble-host = { version = "0.6.0", features = ["default-packet-pool-mtu-255", "scan", "central"], optional = true }
 esp-alloc = { version = "0.9", optional = true }
 bt-hci = { version = "0.8", features = ["uuid"], optional = true }

--- a/crates/microfips-esp32/Cargo.toml
+++ b/crates/microfips-esp32/Cargo.toml
@@ -39,7 +39,7 @@ microfips-esp-transport = { path = "../microfips-esp-transport", features = ["es
 microfips-http-demo = { path = "../microfips-http-demo" }
 microfips-protocol = { path = "../microfips-protocol", features = ["log"] }
 microfips-service = { path = "../microfips-service" }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 esp-hal = { version = "1.0.0", features = ["esp32", "unstable"] }
 esp-rtos = { version = "0.2.0", features = ["esp32", "embassy", "esp-alloc", "esp-radio"] }
 esp-bootloader-esp-idf = { version = "0.4", features = ["esp32"] }

--- a/crates/microfips-esp32s3/Cargo.toml
+++ b/crates/microfips-esp32s3/Cargo.toml
@@ -43,7 +43,7 @@ microfips-esp-transport = { path = "../microfips-esp-transport", features = ["es
 microfips-http-demo = { path = "../microfips-http-demo" }
 microfips-protocol = { path = "../microfips-protocol", features = ["log"] }
 microfips-service = { path = "../microfips-service" }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 esp-hal = { version = "1.0.0", features = ["esp32s3", "unstable"] }
 esp-rtos = { version = "0.2.0", features = ["esp32s3", "embassy", "esp-alloc", "esp-radio"] }
 esp-bootloader-esp-idf = { version = "0.4", features = ["esp32s3"] }

--- a/crates/microfips-esp32s3/Cargo.toml
+++ b/crates/microfips-esp32s3/Cargo.toml
@@ -54,7 +54,7 @@ embassy-sync = "0.7.2"
 embedded-io-async = "0.7"
 heapless = "0.9"
 static_cell = "2"
-esp-radio = { version = "0.17.0", default-features = false, features = ["esp32s3", "ble", "wifi", "unstable"], optional = true }
+esp-radio = { version = "0.18.0", default-features = false, features = ["esp32s3", "ble", "wifi", "unstable"], optional = true }
 trouble-host = { version = "0.6.0", features = ["default-packet-pool-mtu-255", "scan"], optional = true }
 esp-alloc = { version = "0.9", optional = true }
 bt-hci = { version = "0.8", features = ["uuid"], optional = true }

--- a/crates/microfips-protocol/Cargo.toml
+++ b/crates/microfips-protocol/Cargo.toml
@@ -8,7 +8,7 @@ description = "FIPS leaf node protocol: handshake, heartbeat, framing over any t
 microfips-core = { path = "../microfips-core" }
 embassy-time = "0.5.1"
 embassy-futures = "0.1.2"
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 log = { version = "0.4", optional = true }
 
 [dev-dependencies]

--- a/crates/microfips-sim/Cargo.toml
+++ b/crates/microfips-sim/Cargo.toml
@@ -11,7 +11,7 @@ microfips-protocol = { path = "../microfips-protocol", features = ["std"] }
 microfips-service = { path = "../microfips-service" }
 embassy-executor = { version = "0.10.0", features = ["platform-std", "executor-thread"] }
 embassy-time = { version = "0.5.1", features = ["std"] }
-rand_core = { version = "0.6", features = ["getrandom"] }
+rand_core = { version = "0.10", features = ["getrandom"] }
 rand = "0.9"
 hex = "0.4"
 k256 = { version = "0.13", features = ["arithmetic", "ecdsa", "ecdh"] }

--- a/crates/microfips/Cargo.toml
+++ b/crates/microfips/Cargo.toml
@@ -24,7 +24,7 @@ microfips-core = { path = "../microfips-core" }
 microfips-http-demo = { path = "../microfips-http-demo" }
 microfips-protocol = { path = "../microfips-protocol" }
 microfips-service = { path = "../microfips-service" }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 embassy-stm32 = { version = "0.6.0", features = [
     "stm32f469ni",
     "unstable-pac",

--- a/crates/microfips/src/main.rs
+++ b/crates/microfips/src/main.rs
@@ -75,6 +75,52 @@ async fn main(_spawner: Spawner) {
     }
     let p = embassy_stm32::init(config);
 
+    // After a soft reset (SYSRESETREQ from st-flash), the USB OTG FS peripheral
+    // can be left in an inconsistent state where the PHY doesn't re-enumerate.
+    // Cycling the RCC clock + core soft reset + PHY power cycle ensures a clean
+    // start regardless of how we got here. See ccid-firmware-rs issue #15.
+    {
+        let rcc = embassy_stm32::pac::RCC;
+
+        rcc.ahb2enr().modify(|w| w.set_otgfsen(false));
+        cortex_m::asm::delay(100);
+        rcc.ahb2enr().modify(|w| w.set_otgfsen(true));
+
+        rcc.ahb2rstr().modify(|w| w.set_otgfsrst(true));
+        cortex_m::asm::delay(100);
+        rcc.ahb2rstr().modify(|w| w.set_otgfsrst(false));
+        cortex_m::asm::delay(100);
+
+        // USB_OTG_FS_GLOBAL base: 0x5000_0000
+        // GRSTCTL offset: 0x010, GCCFG offset: 0x038
+        let otg_global = 0x5000_0000usize as *mut u32;
+        unsafe {
+            // GRSTCTL.AHBIDL (bit 31) — wait for AHB idle before reset
+            let mut timeout = 100_000u32;
+            while otg_global.add(0x010 / 4).read_volatile() & (1 << 31) == 0 {
+                timeout -= 1;
+                if timeout == 0 {
+                    break;
+                }
+            }
+
+            // GRSTCTL.CSRST (bit 0) — core soft reset, self-clearing
+            otg_global.add(0x010 / 4).write_volatile(1);
+            timeout = 100_000u32;
+            while otg_global.add(0x010 / 4).read_volatile() & 1 != 0 {
+                timeout -= 1;
+                if timeout == 0 {
+                    break;
+                }
+            }
+
+            // GCCFG.PWRDWN (bit 16) — PHY power cycle
+            otg_global.add(0x038 / 4).write_volatile(0);
+            cortex_m::asm::delay(100);
+            otg_global.add(0x038 / 4).write_volatile(1 << 16);
+        }
+    }
+
     let mut leds = Leds {
         green: Output::new(p.PG6, Level::Low, Speed::Low),
         orange: Output::new(p.PD4, Level::Low, Speed::Low),


### PR DESCRIPTION
## Summary

Fixes #105 — USB OTG FS doesn't re-enumerate after `st-flash` soft reset.

Adds an explicit PHY reset sequence between `embassy_stm32::init()` and `Driver::new_fs()`:

1. RCC AHB2ENR.OTGFSEN clock cycle (disable → enable)
2. RCC AHB2RSTR.OTGFSRST peripheral reset (assert → deassert)
3. GRSTCTL.CSRST core soft reset
4. GCCFG.PWRDWN PHY power cycle (clear → set)

## Why This Is Needed

After `st-flash` (SYSRESETREQ without NRST), the USB PHY retains stale state. Neither `embassy-usb-synopsys-otg` nor `embassy-stm32`'s RCC init performs the full reset sequence needed to unwedge the PHY.

## Verification

Same fix hardware-verified on STM32F746-DISCO in ccid-firmware-rs (commit 28e6fee, issue #15). The STM32F469 uses an identical OTG FS peripheral at the same base address (0x5000_0000).

## Related

- ccid-firmware-rs#15 — original fix (STM32F746, hardware-verified)
- Amperstrand/micronuts#34 — same fix for micronuts
- Amperstrand/gm65-scanner#56 — same fix for gm65-scanner (sync + async)