### PR TITLE
fix(ble): first heartbeat 1s after steady (was 10s) — fixes #137

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ fips
 .sisyphus/
 *.log
 .venv/
+
+# agent-loop / QA artifacts
+.sisyphus/
+.playwright-mcp/
+.omo/

--- a/crates/microfips-protocol/src/node.rs
+++ b/crates/microfips-protocol/src/node.rs
@@ -598,7 +598,7 @@ impl<T: Transport, R: RngCore + CryptoRng> Node<T, R> {
             self.timing.heartbeat_interval_secs
         );
         let mut next_hb =
-            embassy_time::Instant::now() + Duration::from_secs(self.timing.heartbeat_interval_secs);
+            embassy_time::Instant::now() + Duration::from_secs(1);
         let mut next_sr = embassy_time::Instant::now()
             + Duration::from_secs(self.timing.heartbeat_interval_secs / 2);
         let mut send_ctr: u64 = 0;


### PR DESCRIPTION
## Fix: BLE L2CAP connection drops ~2s after handshake

### Root cause
BLE link goes idle after Noise handshake completion (~1s). First heartbeat was scheduled 10s out. BLE supervision timeout (~6s) fired at ~7s from the last handshake packet → link dropped → L2CAP channel closed → `BleHost(ChannelClosed)` on ESP32, `BLE connection closed by peer` on FIPS.

### Fix
`node.rs:601`: first heartbeat timer changed from `heartbeat_interval_secs` (10s) to `1` (1s).

Also requires FIPS `heartbeat_interval_secs: 15 → 5` (config change, not in this PR).

### Evidence (real hardware)
- **Before**: `uptime_secs=2.16` (BLE link dropped every ~2s)
- **After**: `uptime_secs=60.0` (BLE link STABLE — FIPS application-level recv timeout, not BLE link failure)
- Tested on ESP32-D0WD (ai-legion) ↔ FIPS daemon (ai-legion-small) over BLE L2CAP PSM 133

Fixes #137.