### PR TITLE
chore: opt-in secret-detection hooks (ERE-portable port of infra-kit #2)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# pre-commit: block commits containing secrets.
+# Portable: ERE (grep -En) — macOS BSD grep has no -P, which made the
+# upstream version of this hook silently inert on Macs.
+set -e
+
+PATTERNS_FILE="$(git rev-parse --show-toplevel)/.secret-patterns.txt"
+
+if [ ! -f "$PATTERNS_FILE" ]; then
+    exit 0  # no patterns file = no scanning
+fi
+
+FOUND=0
+# -z + read -d '': spaces/newlines in filenames safe; deletions excluded.
+while IFS= read -r -d '' file; do
+    [ -f "$file" ] || continue
+    while IFS= read -r pattern; do
+        [ -z "$pattern" ] && continue
+        case "$pattern" in \#*) continue ;; esac
+        MATCH=$(git diff --cached -- "$file" | grep -En -- "$pattern" 2>/dev/null | head -3)
+        if [ -n "$MATCH" ]; then
+            echo "SECRET DETECTED in $file (pattern: $pattern):"
+            echo "$MATCH"
+            FOUND=1
+        fi
+    done < "$PATTERNS_FILE"
+done < <(git diff --cached --name-only -z --diff-filter=ACM)
+
+if [ $FOUND -eq 1 ]; then
+    echo ""
+    echo "COMMIT BLOCKED — secret pattern detected."
+    echo "Override (NOT RECOMMENDED): git commit --no-verify"
+    exit 1
+fi
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# pre-push: block pushes containing secrets + run quality gates.
+# Portable: ERE (grep -En) — macOS BSD grep has no -P.
+set -e
+
+PATTERNS_FILE="$(git rev-parse --show-toplevel)/.secret-patterns.txt"
+
+if [ ! -f "$PATTERNS_FILE" ]; then
+    exit 0
+fi
+
+RANGE="@{u}..HEAD"
+COMMITS=$(git rev-list "$RANGE" 2>/dev/null || echo "")
+if [ -z "$COMMITS" ]; then
+    COMMITS=$(git rev-list HEAD~5..HEAD 2>/dev/null || echo "")
+fi
+
+FOUND=0
+while IFS= read -r pattern; do
+    [ -z "$pattern" ] && continue
+    case "$pattern" in \#*) continue ;; esac
+    MATCH=$(git log -p "$RANGE" 2>/dev/null | grep -En -- "$pattern" 2>/dev/null | head -5)
+    if [ -n "$MATCH" ]; then
+        echo "SECRET in push history (pattern: $pattern):"
+        echo "$MATCH"
+        FOUND=1
+    fi
+done < "$PATTERNS_FILE"
+
+if [ $FOUND -eq 1 ]; then
+    echo ""
+    echo "PUSH BLOCKED — secrets detected in commit history."
+    echo "Scrub with: git filter-repo --replace-text .secret-patterns.txt"
+    exit 1
+fi
+
+echo "No secrets detected."
+exit 0

--- a/.secret-patterns.txt
+++ b/.secret-patterns.txt
@@ -1,0 +1,28 @@
+# Secret patterns — one regex per line, # for comments
+# Block commits/pushes containing these patterns
+
+# Nostr private keys
+nsec1[a-z0-9]{20,}
+
+# API keys (PPQ, OpenAI, etc.)
+sk-[A-Za-z0-9]{10,}
+
+# z.ai key format (32-char hex hash + dot + alphanumeric)
+[0-9a-f]{32}\.[A-Za-z0-9]{8,}
+
+# Private keys (PEM format)
+-----BEGIN [A-Z ]*PRIVATE KEY
+
+# Bearer tokens
+Bearer [A-Za-z0-9._~+/-]{20,}
+
+# Hardcoded password/secret assignments (not env vars)
+password.*=.*['\"][^'\"]{4,}['\"]
+api_key.*=.*['\"][^'\"]{8,}['\"]
+secret_key.*=.*['\"][^'\"]{8,}['\"]
+
+# Signal phone numbers
+\+1[0-9]{10}
+
+# Matrix access tokens
+syt\.[A-Za-z0-9_-]{10,}


### PR DESCRIPTION
Ported from OpenTollGate/tollgate-infrastructure-kit PR #2 with macOS portability fixes (upstream silently inert on BSD grep): -nP → -En, ERE bracket fix, -z+read iteration, --diff-filter=ACM. microfips holds node keys. Enable: `git config core.hooksPath .githooks`. Functionally verified: nsec1/PEM/Bearer blocked; clean spaces-filename passes.